### PR TITLE
Fix usage instructions in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,5 +10,5 @@ See https://github.com/NixOS/nix/issues/3862
 ## Usage
 
 ```
-inputs.in-nix.packages.x86_64-linux.patchNix <your nix package>
+inputs.in-nix.packages.x86_64-linux.default.patchNix <your nix package>
 ```


### PR DESCRIPTION
Judging by [this](https://github.com/viperML/in-nix/blob/ffd4d386f38c35d09fd278fc5040161e3c3ca5f6/flake.nix#L12) and by my own trial and error, the correct way to use this is by using `inputs.in-nix.packages.x86_64-linux.default.patchNix <your nix package>` instead of what is there right now in the readme.